### PR TITLE
Accept configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ optimization ideas.
   curl http://localhost:9000/reset
   ```
 
+## Documentation
+
+### VM
+
+The VirtualBox VM is configured via environment variables in the shell where
+`vagrant up` is run.
+
+#### `GROUNDHAR_CPUS`
+
+The number of virtual CPUs the VM should have. Defaults to 4.
+
+#### `GROUNDHAR_DEVTOOLS_PORT`
+
+The port on the host where the Chrome DevTools is exposed. Defaults to 9222.
+
+#### `GROUNDHAR_MEMORY`
+
+The amount of memory in megabytes to reserve for the VM. Defaults to 2048.
+
+#### `GROUNDHAR_NETWORK_IP`
+
+The IP address of the VM on the `groundhar-day` [VirtualBox internal network][].
+
+#### `GROUNDHAR_SERVER_PORT`
+
+The port on the host where the GroundHAR Day server is exposed. Defaults to
+9000.
+
 [HAR]: http://www.softwareishard.com/blog/har-12-spec/
 [Vagrant]: https://www.vagrantup.com/downloads.html
 [VirtualBox]: https://www.virtualbox.org/wiki/Downloads
+[VirtualBox internal network]: https://www.virtualbox.org/manual/ch06.html#network_internal

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The amount of memory in megabytes to reserve for the VM. Defaults to 2048.
 #### `GROUNDHAR_NETWORK_IP`
 
 The IP address of the VM on the `groundhar-day` [VirtualBox internal network][].
+Defaults to 192.168.42.1.
 
 #### `GROUNDHAR_SERVER_PORT`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,23 +1,29 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+devtools_port = ENV['GROUNDHAR_DEVTOOLS_PORT'] || 9222
+server_port = ENV['GROUNDHAR_SERVER_PORT'] || 9000
+internal_network_ip = ENV['GROUNDHAR_NETWORK_IP'] || "192.168.42.1"
+memory = ENV['GROUNDHAR_MEMORY'] || 2048
+cpus = ENV['GROUNDHAR_CPUS'] || 4
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 2048
-    v.cpus = 4
+    v.memory = memory
+    v.cpus = cpus
   end
 
   # forward port for Chrome devtools
-  config.vm.network "forwarded_port", guest: 9222, host: 9222
+  config.vm.network "forwarded_port", guest: 9222, host: devtools_port
 
   # forward port for GroundHAR Day server
-  config.vm.network "forwarded_port", guest: 9000, host: 9000
+  config.vm.network "forwarded_port", guest: 9000, host: server_port
 
   # Connect to the GroundHAR Day VirtualBox internal network
   config.vm.network "private_network",
-    ip: "192.168.42.1",
+    ip: internal_network_ip,
     virtualbox__intnet: "groundhar-day"
 
   # Mount GroundHAR Day code


### PR DESCRIPTION
Allow the user to configure the following properties of the VM via environment
variables:
- number of CPUs
- RAM size
- IP address of the `groundhar-day` VirtualBox internal network[1]
- host port where the GroundHAR Day server is exposed
- host port where the DevTools of the headless chrome instance in the VM are
  exposed

Partial progress on #10